### PR TITLE
Adiciona documentação para a seção de models

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,16 +5,17 @@ Pré-requisito: Docker instalado
 ## Rodando a aplicação
 
 ```
+# Constrói a imagem baseada no Dockerfile
 docker compose build
+
+# Configuração inicial do banco de dados, já alimentado com exemplos pré-definidos
+docker compose run --rm web bin/rails db:setup
+
+# Sobe o servidor
 docker compose up
 ```
 
 A aplicação agora pode ser acessada em http://localhost:3000
-
-## Executando a migration
-```
-docker compose exec web rails db:migrate
-```
 
 ## Para rodar os testes
 ```

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,9 +1,62 @@
-# This file should ensure the existence of records required to run the application in every environment (production,
-# development, test). The code here should be idempotent so that it can be executed at any point in every environment.
-# The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
-#
-# Example:
-#
-#   ["Action", "Comedy", "Drama", "Horror"].each do |genre_name|
-#     MovieGenre.find_or_create_by!(name: genre_name)
-#   end
+Book.create!(
+  title: "Desesterro",
+  publisher: "Record",
+  language: "Portuguese",
+  quantity: 10,
+)
+
+Book.create!(
+  title: "O habitante das falhas subterrâneas",
+  publisher: "Oito e meio",
+  language: "Portuguese",
+  quantity: 0,
+)
+
+Book.create!(
+  title: "Convite à Filosofia",
+  publisher: "Ática",
+  language: "Portuguese",
+  quantity: 9
+)
+
+Book.create!(
+  title: "Fim",
+  publisher: "Companhia das Letras",
+  language: "Portuguese",
+  quantity: 6
+)
+
+Book.create!(
+  title: "Quarto de despejo - Diário de uma favelada",
+  publisher: "Ática",
+  language: "Portuguese",
+  quantity: 0
+)
+
+Book.create!(
+  title: "Half of a Yellow Sun",
+  publisher: "4th Estate",
+  language: "English",
+  quantity: 3
+)
+
+Book.create!(
+  title: "Pride and Prejudice",
+  publisher: "Wordsworth Editions Ltd",
+  language: "English",
+  quantity: 7
+)
+
+Book.create!(
+  title: "Wuthering Heights",
+  publisher: "Wordsworth Editions Ltd",
+  language: "English",
+  quantity: 0
+)
+
+Book.create!(
+  title: "The Color Purple",
+  publisher: "W&N",
+  language: "English",
+  quantity: 5
+)

--- a/docs/3-models/README.md
+++ b/docs/3-models/README.md
@@ -38,6 +38,28 @@ No console, experimente criar um livro:
 Após executar o comando `book.save`, confira se o valor retornado corresponde a `true` - isso
 significa que o objeto foi salvo corretamente.
 
+Note que ao rodar o comando para o setup do banco de dados especificado no README inicial do
+projeto, nós também populamos automaticamente alguns livros no banco de dados. Agora podemos
+consultar esses livros no console. Experimente executar alguns comandos e preste atenção aos
+resultados obtidos.
+
+Sugestões de comandos:
+- `Book.count`
+- `Book.first`
+- `Book.pluck(:title)`
+- `Book.find_by(language: "Portuguese")`
+- `Book.where(language: "Portuguese")`
+
+Seguindo essa linha, tente encontrar as respostas para as seguintes perguntas:
+
+- Quantos livros registrados estão escritos em Português?
+- Quantos livros registrados estão escritos em idiomas estrangeiros?
+- Quantos livros encontram-se indisponíveis?
+- Quais os títulos dos livros que se encontram indisponíveis?
+- Existe algum livro publicado pela editora Ática disponível para empréstimo?
+
+Material de consulta: [Recuperando Objetos do Banco de Dados(Guia Rails)](https://guiarails.com.br/active_record_querying.html#recuperando-objetos-do-banco-de-dados).
+
 ## Testes
 Para os testes, usaremos o [RSpec](https://rspec.info/).
 

--- a/docs/3-models/README.md
+++ b/docs/3-models/README.md
@@ -1,9 +1,112 @@
 # Models
 
-https://github.com/lidimayra/ruby-empowers/pull/6
+O model Book já foi criado para esse projeto e está disponível em app/models/book.rb. Nós o geramos
+com o gerador automático fornecido pelo Rails:
 
-Potenciais TODOs:
-- Implementação do model: `bin/rails g model book`
-- Acesso ao console: `bin/rails c`
-- Básicos de ActiveRecord
-- Validação
+```
+docker compose run --rm web bin/rails g model book
+```
+
+O gerador nos auxilia com a definição básica para o model e a respectiva migração responsável por
+criar a tabela no banco de dados. Cada objeto criado como uma instância da classe book é persistido
+na tabela `books`.
+
+Estipulamos aqui que cada livro pode ter os seguintes atributos:
+- Título (title)
+- Editora (publisher)
+- Idioma (language)
+- Quantidade (quantity)
+
+Podemos usar o Rails console para criar e consultar alguns livros.
+No terminal de comando, abra o console com o seguinte comando:
+
+```
+docker compose run --rm web bin/rails c
+```
+
+No console, experimente criar um livro:
+
+```
+> book = Book.new
+> book.title = "<insira aqui o título que quiser>"
+> book.publisher = "<insira aqui o nome de uma editora>"
+> book.language = "<insira aqui o idioma>"
+> book.quantity = "<insira aqui um número inteiro correspondendo a quantidade de livros>"
+> book.save
+```
+
+Após executar o comando `book.save`, confira se o valor retornado corresponde a `true` - isso
+significa que o objeto foi salvo corretamente.
+
+## Testes
+Para os testes, usaremos o [RSpec](https://rspec.info/).
+
+Já criamos o arquivo de testes para o model Book e o definimos em `spec/models/book_spec.rb`. Abra
+o arquivo e mantenha-o lado a lado com o arquivo contendo o nosso model.
+
+A ideia é não alterar a implementação dos testes por enquanto. Queremos implementar a lógica em
+Book até que todos os testes passem. Não precisamos nos preocupar com qualidade de código, vamos
+focar em implementar o mínimo possível para alcançar o comportamento esperado. Uma vez que os
+testes estiverem verdes, podemos considerar melhorias em ambos os lados (tanto nos testes quando
+no model).
+
+Todos os testes estão falhando nesse momento já que o model Book está vazio.
+Colocamos esses testes em pendência através da adição da linha `pending "Make it pass"` no início de
+cada um deles.
+
+Vamos comecar! No primeiro teste do arquivo, onde testamos a validamos de presença do atributo
+title, delete a linha que marca a pendência do teste e execute-o:
+
+```
+docker compose run --rm web bin/rspec spec/models/book_spec.rb:5
+```
+
+Aqui estamos acrescentando um `:5` no final da linha para indicar que estamos exclusivamente
+interessadas no teste definido na linha 5 do nosso arquivo. Essa abordagem nos ajudar a manter o
+foco apenas no que nos interessa e excluir ruídos.
+
+O teste agora deve estar falhando com a seguinte mensagem de erro exibida em vermelho:
+
+```
+ 1) Book#validations validates presence of title
+     Failure/Error: expect(Book.new).to validate_presence_of :title
+
+       Expected Book to validate that :title cannot be empty/falsy, but this
+       could not be proved.
+         After setting :title to ‹""›, the matcher expected the Book to be
+         invalid, but it was valid instead.
+```
+
+Sempre preste muita atenção ao que a mensagem de erro diz (use um tradutor para facilitar se
+preferir). Nesse caso, está nos dizendo que mesmo ao usar um valor vazio para o título, o objeto foi
+considerado válido, portanto, a validação para o atributo título está funcionando.
+
+Isso faz sentido, dado que nunca a implementamos.
+
+Agora vamos para o código do model.
+Implemente o código necessário para que o teste passe.
+
+Material de consulta: [Validações do
+ActiveRecord (Guia Rails)](https://guiarails.com.br/active_record_validations.html).
+
+O teste passou? Ótimo.
+O seu código agora está testado e você pode se sentir segura para refatora-lo como quiser sem medo
+de que a validação quebre. Nesse primeiro exercício, provavelmente não temos muito espaço para
+refactor devido a simplicidade do exemplo, mas essa linha de raciocínio será bem-vinda conforme a
+complexidade aumentar.
+
+Vamos para o próximo bloco de testes.
+Note que eles estão dentro de um bloco definido como `describe "#details"`. Isso indica que os
+testes contidos nesse bloco testarão a implementação de um método em Book chamado `details`. Note
+que o bloco já está definido, mas por enquanto ainda está vazio. Novamente, vamos repetir um
+processo similar ao anterior: remova a linha que marca a pendência do primeiro teste no bloco, rode
+o teste, veja-o falhar. Agora direcione o foco para a implementação do método no model e garante que
+o teste passe. Uma vez que o teste passar, fique à vontade para aplicar melhorias no código como
+preferir.
+
+Faça isso com todos os testes contidos no arquivo `book_spec.rb` até que todos estejam verdes.
+Ao final, rode todos eles:
+
+```
+docker compose run --rm web bin/rspec spec/models/book_spec.rb
+```

--- a/spec/models/book_spec.rb
+++ b/spec/models/book_spec.rb
@@ -1,21 +1,20 @@
 require 'rails_helper'
 
-# Todos os testes estão falhando nesse momento já que o model Book está vazio.
-# A ideia é não alterar a implementação dos testes por enquanto. Queremos implementar a lógica em
-# Book até que todos os testes passem. Não precisamos nos preocupar com qualidade de código, vamos
-# focar em implementar o mínimo possível para alcançar o comportamento esperado. Uma vez que os
-# testes estiverem verdes, podemos considerar melhorias em ambos os lados (tanto nos testes quando
-# no model)
-
 RSpec.describe Book, type: :model do
   describe "#validations" do
-    it { expect(Book.new).to validate_presence_of :title }
+    it "validates presence of title" do
+      pending "Make it pass"
+
+      expect(Book.new).to validate_presence_of :title
+    end
   end
 
   describe "#details" do
     context "with publisher" do
       context "with language" do
         it "includes title, publisher and language" do
+          pending "Make it pass"
+
           book = Book.new(title: "Vida de Gato", publisher: "Planeta", language: "Portuguese")
 
           expect(book.details).to eq "Vida de Gato (Planeta) - Portuguese"
@@ -24,6 +23,8 @@ RSpec.describe Book, type: :model do
 
       context "without language" do
         it "includes title and publisher" do
+          pending "Make it pass"
+
           book = Book.new(title: "Vida de Gato", publisher: "Planeta")
 
           expect(book.details).to eq "Vida de Gato (Planeta)"
@@ -34,6 +35,8 @@ RSpec.describe Book, type: :model do
     context "without publisher" do
       context "with language" do
         it "includes title and language mentioning unknown publisher" do
+          pending "Make it pass"
+
           book = Book.new(title: "Vida de Gato", language: "Portuguese")
 
           expect(book.details).to eq "Vida de Gato (Unknown Publisher) - Portuguese"
@@ -42,6 +45,8 @@ RSpec.describe Book, type: :model do
 
       context "without language" do
         it "includes title mentioning unkown publisher" do
+          pending "Make it pass"
+
           book = Book.new(title: "Vida de Gato")
 
           expect(book.details).to eq "Vida de Gato (Unknown Publisher)"


### PR DESCRIPTION
Adiciona início da documentação para a seção de models
Orientações sobre o uso do rails console e introdução a testes e ao fluxo TDD

(esse aqui to abrindo direto pra main já que a parte de model já foi iniciada na main branch, aí parece fazer mais sentido já manter tudo lá do que deixar picado)